### PR TITLE
Add ALB module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-lb module
 
-Module for handling load balancers, listeners, target groups and route53 records creation. It also handles SSL certificates creation and validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional. 
+Module for handling load balancers, listeners, target groups and route53 records creation. It also handles SSL certificates validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional. 
 
 Security groups are handled internally and only allow http and https traffic in.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module "lb" {
 }
 ```
 
-As optional, extra target groups can be set. Those will be reached through path based routing.
+As optional, extra target groups can be set. Those could be then reached through path based routing.
 ```hcl
   path_target_groups   = [
     {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-lb module
 
-Module for handling load balancers, listeners, target groups and route53 records creation. It also handles SSL certificates validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional. 
+Module for handling application load balancers, listeners, target groups and route53 records creation. It also handles SSL certificates validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional. 
 
 Security groups are handled internally and only allow http and https traffic in.
 
@@ -65,6 +65,25 @@ As optional, extra target groups can be set. Those could be then reached through
 ```
 
 For other optional inputs, see Inputs section
+
+## Enabling logging
+ALB logs can be enabled by setting the following input:
+```hcl
+  "log_bucket" = "arn-of-an-existing-bucket"
+```
+When empty, there are no logs saved.
+
+## Enabling OKTA
+OKTA can be enabled with the following inputs:
+```hcl
+  okta_enabled = true
+  secret_name  = "aws-secret-name"
+```
+
+The secret is a JSON key-value pair that must contain the following keys:
+- okta_client_id
+- okta_client_secret
+- okta_login_url
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ as described in the `.pre-commit-config.yaml` file
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 
@@ -85,15 +87,44 @@ No modules.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_acm_certificate.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate_validation.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
+| [aws_lb.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_route53_record.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.app_ssl_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_security_group.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_secretsmanager_secret.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret_version.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_url"></a> [app\_url](#input\_app\_url) | the domain name of the Application | `string` | n/a | yes |
+| <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | the S3 Bucket where to store the logs - if the bucekt name is empty logging is disabled | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name for the load balancer. | `string` | n/a | yes |
+| <a name="input_okta_enabled"></a> [okta\_enabled](#input\_okta\_enabled) | if okta is enabled or not for the ALB | `bool` | `false` | no |
+| <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | the AWS Secret manager Secret name of the Secret where okta id and okta secret are stored. They should be stored as okta\_client\_id and okta\_client\_secret key | `string` | `""` | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of public subnet IDs for the load balancer. | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to the load balancer and associated resources. | `map(string)` | n/a | yes |
+| <a name="input_target_groups"></a> [target\_groups](#input\_target\_groups) | Definition of the target groups. Each target group is accessed via path based routing. | <pre>list(object({<br>    name     = string<br>    protocol = string<br>    port     = number<br>    health_check = object({<br>      path     = string<br>      port     = string<br>      protocol = string<br>      matcher  = string<br>    })<br>    tags = map(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC in which to create the load balancer. | `string` | n/a | yes |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | the Route 53 zone id | `string` | n/a | yes |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_load_balancer_arn"></a> [load\_balancer\_arn](#output\_load\_balancer\_arn) | The ARN sffix of the load balancer. |
+| <a name="output_load_balancer_arn_suffix"></a> [load\_balancer\_arn\_suffix](#output\_load\_balancer\_arn\_suffix) | The ARN suffix of the load balancer. |
+| <a name="output_load_balancer_dns_name"></a> [load\_balancer\_dns\_name](#output\_load\_balancer\_dns\_name) | The DNS of the load balancer. |
+| <a name="output_target_group_arns"></a> [target\_group\_arns](#output\_target\_group\_arns) | A list of ARNs for all target groups associated with the load balancer. |
+| <a name="output_target_group_arns_suffix"></a> [target\_group\_arns\_suffix](#output\_target\_group\_arns\_suffix) | A list of ARNs suffix for all target groups associated with the load balancer. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ No modules.
 | [aws_lb.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener_rule.https_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_target_group.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_route53_record.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.app_ssl_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-lb module
 
-Module for handling application load balancers, listeners, target groups and route53 records creation. It also handles SSL certificates validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. The name of the target group is used as the path. For example, if the target group name is `api` then it will be reachable at `hostname/api/*`, then . By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional. 
+Module for handling application load balancers, listeners, target groups and route53 records creation. It also handles SSL certificates validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. The name of the target group is used as the path. For example, if the target group name is `api` then it will be reachable at `hostname/api/*`, then . By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional.
 
 Security groups are handled internally and only allow http and https traffic in.
 
@@ -11,7 +11,7 @@ module "lb" {
   app_url              = "my-subdomain.domain"
   name                 = "my-deployment"
   vpc_id               = local.vpc_id
-  subnets              = data.terraform_remote_state.core_infrastructure.outputs.public_subnets.ids
+  subnets              = local.public_subnet.ids
   zone_id              = data.aws_route53_zone.my_zone.zone_id
   default_target_group = {
     name = "client"
@@ -152,7 +152,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_url"></a> [app\_url](#input\_app\_url) | the domain name of the Application | `string` | n/a | yes |
 | <a name="input_default_target_group"></a> [default\_target\_group](#input\_default\_target\_group) | Definition of the default target group. The one reachable by default ('/'). | <pre>object({<br>    name     = string<br>    protocol = string<br>    port     = number<br>    health_check = object({<br>      path     = string<br>      port     = string<br>      protocol = string<br>      matcher  = string<br>    })<br>    tags = map(string)<br>  })</pre> | n/a | yes |
-| <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | the S3 Bucket where to store the logs - if the bucekt name is empty logging is disabled | `string` | `""` | no |
+| <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | the existing S3 Bucket name where to store the logs - if the bucket name is empty logging is disabled | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name for the load balancer. | `string` | n/a | yes |
 | <a name="input_okta_enabled"></a> [okta\_enabled](#input\_okta\_enabled) | if okta is enabled or not for the ALB | `bool` | `false` | no |
 | <a name="input_path_target_groups"></a> [path\_target\_groups](#input\_path\_target\_groups) | Definition of the target groups. Each target group is accessed via path based routing. | <pre>list(object({<br>    name     = string<br>    protocol = string<br>    port     = number<br>    health_check = object({<br>      path     = string<br>      port     = string<br>      protocol = string<br>      matcher  = string<br>    })<br>    tags = map(string)<br>  }))</pre> | n/a | yes |
@@ -171,6 +171,7 @@ No modules.
 | <a name="output_load_balancer_arn_suffix"></a> [load\_balancer\_arn\_suffix](#output\_load\_balancer\_arn\_suffix) | The ARN suffix of the load balancer. |
 | <a name="output_load_balancer_dns_name"></a> [load\_balancer\_dns\_name](#output\_load\_balancer\_dns\_name) | The DNS of the load balancer. |
 | <a name="output_path_target_groups_arn"></a> [path\_target\_groups\_arn](#output\_path\_target\_groups\_arn) | Path base routed TG arn |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The security group ID linked to the load balancer |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ No modules.
 | [aws_lb.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_listener_rule.https_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_target_group.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_route53_record.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.app_ssl_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ module "lb" {
 
 As optional, extra target groups can be set. Those could be then reached through path based routing.
 ```hcl
+module "lb" {
+  source               = "github.com/tx-pts-dai/terraform-aws-lb"
+  ...
   path_target_groups   = [
     {
       name = "ws"
@@ -62,6 +65,7 @@ As optional, extra target groups can be set. Those could be then reached through
       }
     }
   ]
+}
 ```
 
 For other optional inputs, see Inputs section

--- a/README.md
+++ b/README.md
@@ -166,7 +166,11 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_default_target_group_arn"></a> [default\_target\_group\_arn](#output\_default\_target\_group\_arn) | Default TG arn |
+| <a name="output_load_balancer_arn"></a> [load\_balancer\_arn](#output\_load\_balancer\_arn) | The ARN of the load balancer. |
+| <a name="output_load_balancer_arn_suffix"></a> [load\_balancer\_arn\_suffix](#output\_load\_balancer\_arn\_suffix) | The ARN suffix of the load balancer. |
 | <a name="output_load_balancer_dns_name"></a> [load\_balancer\_dns\_name](#output\_load\_balancer\_dns\_name) | The DNS of the load balancer. |
+| <a name="output_path_target_groups_arn"></a> [path\_target\_groups\_arn](#output\_path\_target\_groups\_arn) | Path base routed TG arn |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-lb module
 
-Module for handling load balancers, listeners, target groups, route53 records creation. It also handles SSL certificates creation and validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional. 
+Module for handling load balancers, listeners, target groups and route53 records creation. It also handles SSL certificates creation and validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional. 
 
 Security groups are handled internally and only allow http and https traffic in.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-lb module
 
-Module for handling application load balancers, listeners, target groups and route53 records creation. It also handles SSL certificates validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional. 
+Module for handling application load balancers, listeners, target groups and route53 records creation. It also handles SSL certificates validation through DNS. Besides the default target group, multiple target groups can be reached through path based routing from the same load balancer. The name of the target group is used as the path. For example, if the target group name is `api` then it will be reachable at `hostname/api/*`, then . By default, all http traffic is redirected to https. The load balancer is also protected via Okta as optional. 
 
 Security groups are handled internally and only allow http and https traffic in.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ No modules.
 | [aws_lb.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_listener_rule.https_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
+| [aws_lb_target_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.path](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_route53_record.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.app_ssl_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_security_group.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -106,13 +108,14 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_url"></a> [app\_url](#input\_app\_url) | the domain name of the Application | `string` | n/a | yes |
+| <a name="input_default_target_group"></a> [default\_target\_group](#input\_default\_target\_group) | Definition of the default target group. The one reachable by default ('/'). | <pre>object({<br>    name     = string<br>    protocol = string<br>    port     = number<br>    health_check = object({<br>      path     = string<br>      port     = string<br>      protocol = string<br>      matcher  = string<br>    })<br>    tags = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | the S3 Bucket where to store the logs - if the bucekt name is empty logging is disabled | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name for the load balancer. | `string` | n/a | yes |
 | <a name="input_okta_enabled"></a> [okta\_enabled](#input\_okta\_enabled) | if okta is enabled or not for the ALB | `bool` | `false` | no |
+| <a name="input_path_target_groups"></a> [path\_target\_groups](#input\_path\_target\_groups) | Definition of the target groups. Each target group is accessed via path based routing. | <pre>list(object({<br>    name     = string<br>    protocol = string<br>    port     = number<br>    health_check = object({<br>      path     = string<br>      port     = string<br>      protocol = string<br>      matcher  = string<br>    })<br>    tags = map(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | the AWS Secret manager Secret name of the Secret where okta id and okta secret are stored. They should be stored as okta\_client\_id and okta\_client\_secret key | `string` | `""` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of public subnet IDs for the load balancer. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to the load balancer and associated resources. | `map(string)` | n/a | yes |
-| <a name="input_target_groups"></a> [target\_groups](#input\_target\_groups) | Definition of the target groups. Each target group is accessed via path based routing. | <pre>list(object({<br>    name     = string<br>    protocol = string<br>    port     = number<br>    health_check = object({<br>      path     = string<br>      port     = string<br>      protocol = string<br>      matcher  = string<br>    })<br>    tags = map(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC in which to create the load balancer. | `string` | n/a | yes |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | the Route 53 zone id | `string` | n/a | yes |
 
@@ -120,11 +123,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_load_balancer_arn"></a> [load\_balancer\_arn](#output\_load\_balancer\_arn) | The ARN sffix of the load balancer. |
-| <a name="output_load_balancer_arn_suffix"></a> [load\_balancer\_arn\_suffix](#output\_load\_balancer\_arn\_suffix) | The ARN suffix of the load balancer. |
 | <a name="output_load_balancer_dns_name"></a> [load\_balancer\_dns\_name](#output\_load\_balancer\_dns\_name) | The DNS of the load balancer. |
-| <a name="output_target_group_arns"></a> [target\_group\_arns](#output\_target\_group\_arns) | A list of ARNs for all target groups associated with the load balancer. |
-| <a name="output_target_group_arns_suffix"></a> [target\_group\_arns\_suffix](#output\_target\_group\_arns\_suffix) | A list of ARNs suffix for all target groups associated with the load balancer. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module "lb" {
 }
 ```
 
-As optional, extra target groups can be set. Those could be then reached through path based routing.
+As optional, extra target groups can be set. Those could be then reached through path based routing. Each target group must specify the following properties. As optional, they can have dedicated tags.
 ```hcl
 module "lb" {
   source               = "github.com/tx-pts-dai/terraform-aws-lb"

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,6 @@ terraform {
   }
 }
 
-
-provider "aws" {
-  region = "eu-central-1"
-}
-
 resource "aws_security_group" "alb" {
   description = "security group from internet to alb"
   vpc_id      = var.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,4 @@
-terraform {
-  required_version = ">= 1.3.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.0"
-    }
-  }
-}
+
 
 provider "aws" {
   region = "eu-central-1"

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "aws_lb_target_group" "default" {
     protocol = var.default_target_group.health_check.protocol
     matcher  = var.default_target_group.health_check.matcher
   }
-  tags = each.value.tags
+  tags = var.default_target_group.tags
 }
   
 resource "aws_lb_target_group" "path" {

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ data "aws_secretsmanager_secret_version" "app" {
 resource "aws_lb_target_group" "app" {
   for_each = { for idx, tg in var.target_groups : idx => tg }
 
-  name                 = each.value.name_prefix
+  name                 = each.value.name
   port                 = each.value.port
   protocol             = each.value.protocol
   target_type          = "ip"

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_lb_target_group" "default" {
   }
   tags = var.default_target_group.tags
 }
-  
+
 resource "aws_lb_target_group" "path" {
   for_each             = { for idx, tg in var.path_target_groups : idx => tg }
   name                 = each.value.name
@@ -156,7 +156,7 @@ resource "aws_lb_listener" "https" {
 }
 
 resource "aws_lb_listener_rule" "https_listener_rule" {
-  for_each = { for idx, tg in var.path_target_groups : idx => tg }
+  for_each     = { for idx, tg in var.path_target_groups : idx => tg }
   listener_arn = aws_lb_listener.https.arn
   action {
     type             = "forward"
@@ -169,7 +169,7 @@ resource "aws_lb_listener_rule" "https_listener_rule" {
     }
   }
 }
-  
+
 resource "aws_acm_certificate" "app" {
   domain_name       = var.app_url
   validation_method = "DNS"

--- a/main.tf
+++ b/main.tf
@@ -157,7 +157,7 @@ resource "aws_lb_listener_rule" "https_listener_rule" {
     for_each = aws_lb_target_group.app
     content {
       type             = "forward"
-      target_group_arn = aws_lb_target_group.app[action.value.name].arn
+      target_group_arn = aws_lb_target_group[countindex].arn
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -141,26 +141,26 @@ resource "aws_lb_listener" "https" {
   }
 }
 
-resource "aws_lb_listener_rule" "https_listener_rule" {
-  listener_arn = aws_lb_listener.https.arn
-
-  dynamic "condition" {
-    for_each = aws_lb_target_group.app
-    content {
-      path_pattern {
-        values = ["/${condition.value.name}/*"]
-      }
-    }
-  }
-
-  dynamic "action" {
-    for_each = aws_lb_target_group.app
-    content {
-      type             = "forward"
-      target_group_arn = aws_lb_target_group[count.index].arn
-    }
-  }
-}
+#resource "aws_lb_listener_rule" "https_listener_rule" {
+#  listener_arn = aws_lb_listener.https.arn
+#
+#  dynamic "condition" {
+#    for_each = aws_lb_target_group.app
+#    content {
+#      path_pattern {
+#        values = ["/${condition.value.name}/*"]
+#      }
+#    }
+#  }
+#
+#  dynamic "action" {
+#    for_each = aws_lb_target_group.app
+#    content {
+#      type             = "forward"
+#      target_group_arn = aws_lb_target_group[count.index].arn
+#    }
+#  }
+#}
 
 resource "aws_acm_certificate" "app" {
   domain_name       = var.app_url

--- a/main.tf
+++ b/main.tf
@@ -142,7 +142,7 @@ resource "aws_lb_listener" "https" {
 }
 
 resource "aws_lb_listener_rule" "https_listener_rule" {
-  for_each = { for idx, tg in var.target_groups : idx => tg }
+  for_each = { for idx, tg in var.path_target_groups : idx => tg }
   listener_arn = aws_lb_listener.https.arn
   action {
     type             = "forward"

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,4 @@
 
-
-provider "aws" {
-  region = "eu-central-1"
-}
-
 resource "aws_security_group" "alb" {
   description = "security group from internet to alb"
   vpc_id      = var.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -128,26 +128,25 @@ resource "aws_lb_listener" "https" {
   }
 }
 
-#resource "aws_lb_listener_rule" "https_listener_rule" {
-#  listener_arn = aws_lb_listener.https.arn
-#
-#  dynamic "condition" {
-#    for_each = aws_lb_target_group.app
-#    content {
-#      path_pattern {
-#        values = ["/${condition.value.name}/*"]
-#      }
-#    }
-#  }
-#
-#  dynamic "action" {
-#    for_each = aws_lb_target_group.app
-#    content {
-#      type             = "forward"
-#      target_group_arn = aws_lb_target_group[count.index].arn
-#    }
-#  }
-#}
+resource "aws_lb_listener_rule" "https_listener_rule" {
+  for_each = aws_lb_target_group.app
+  listener_arn = aws_lb_listener.https.arn
+
+  dynamic "condition" {
+    content {
+      path_pattern {
+        values = ["/${each.value.name}/*"]
+      }
+    }
+  }
+
+  dynamic "action" {
+    content {
+      type             = "forward"
+      target_group_arn = each.value.arn
+    }
+  }
+}
 
 resource "aws_acm_certificate" "app" {
   domain_name       = var.app_url

--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ resource "aws_lb_listener_rule" "https_listener_rule" {
   listener_arn = aws_lb_listener.https.arn
   action {
     type             = "forward"
-    target_group_arn = each.value.arn
+    target_group_arn = aws_alb_target_group.app[each.key].arn
   }
 
   condition {

--- a/main.tf
+++ b/main.tf
@@ -130,23 +130,18 @@ resource "aws_lb_listener" "https" {
 resource "aws_lb_listener_rule" "https_listener_rule" {
   for_each = { for idx, tg in var.target_groups : idx => tg }
   listener_arn = aws_lb_listener.https.arn
-
-  dynamic "condition" {
-    content {
-      path_pattern {
-        values = ["/${each.value.name}/*"]
-      }
-    }
+  action {
+    type             = "forward"
+    target_group_arn = each.value.arn
   }
 
-  dynamic "action" {
-    content {
-      type             = "forward"
-      target_group_arn = each.value.arn
+  condition {
+    path_pattern {
+      values = ["/${each.value.name}/*"]
     }
   }
 }
-
+  
 resource "aws_acm_certificate" "app" {
   domain_name       = var.app_url
   validation_method = "DNS"

--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ resource "aws_lb_listener_rule" "https_listener_rule" {
   listener_arn = aws_lb_listener.https.arn
   action {
     type             = "forward"
-    target_group_arn = aws_alb_target_group.app[each.key].arn
+    target_group_arn = aws_lb_target_group.app[each.key].arn
   }
 
   condition {

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ data "aws_secretsmanager_secret_version" "app" {
 }
 
 resource "aws_lb_target_group" "app" {
-  for_each             = var.target_groups
+  for_each             = { for idx, tg in var.target_groups : idx => tg }
   name                 = each.value.name
   port                 = each.value.port
   protocol             = each.value.protocol
@@ -127,25 +127,25 @@ resource "aws_lb_listener" "https" {
   }
 }
 
-#resource "aws_lb_listener_rule" "https_listener_rule" {
-#  for_each = aws_lb_target_group.app
-#  listener_arn = aws_lb_listener.https.arn
-#
-#  dynamic "condition" {
-#    content {
-#      path_pattern {
-#        values = ["/${each.value.name}/*"]
-#      }
-#    }
-#  }
-#
-#  dynamic "action" {
-#    content {
-#      type             = "forward"
-#      target_group_arn = each.value.arn
-#    }
-#  }
-#}
+resource "aws_lb_listener_rule" "https_listener_rule" {
+  for_each = { for idx, tg in var.target_groups : idx => tg }
+  listener_arn = aws_lb_listener.https.arn
+
+  dynamic "condition" {
+    content {
+      path_pattern {
+        values = ["/${each.value.name}/*"]
+      }
+    }
+  }
+
+  dynamic "action" {
+    content {
+      type             = "forward"
+      target_group_arn = each.value.arn
+    }
+  }
+}
 
 resource "aws_acm_certificate" "app" {
   domain_name       = var.app_url

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,17 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}
+
+
+provider "aws" {
+  region = "eu-central-1"
+}
 
 resource "aws_security_group" "alb" {
   description = "security group from internet to alb"

--- a/main.tf
+++ b/main.tf
@@ -136,31 +136,31 @@ resource "aws_lb_listener" "https" {
     for_each = aws_lb_target_group.app
     content {
       type             = "forward"
-      target_group_arn = aws_lb_target_group.app[*].arn
+      target_group_arn = aws_lb_target_group.app[0].arn
     }
   }
 }
 
-#resource "aws_lb_listener_rule" "https_listener_rule" {
-#  listener_arn = aws_lb_listener.https.arn
-#
-#  dynamic "condition" {
-#    for_each = aws_lb_target_group.app
-#    content {
-#      path_pattern {
-#        values = ["/${condition.value.name}/*"]
-#      }
-#    }
-#  }
-#
-#  dynamic "action" {
-#    for_each = aws_lb_target_group.app
-#    content {
-#      type             = "forward"
-#      target_group_arn = aws_lb_target_group.app[action.value.name].arn
-#    }
-#  }
-#}
+resource "aws_lb_listener_rule" "https_listener_rule" {
+  listener_arn = aws_lb_listener.https.arn
+
+  dynamic "condition" {
+    for_each = aws_lb_target_group.app
+    content {
+      path_pattern {
+        values = ["/${condition.value.name}/*"]
+      }
+    }
+  }
+
+  dynamic "action" {
+    for_each = aws_lb_target_group.app
+    content {
+      type             = "forward"
+      target_group_arn = aws_lb_target_group.app[action.value.name].arn
+    }
+  }
+}
 
 resource "aws_acm_certificate" "app" {
   domain_name       = var.app_url

--- a/main.tf
+++ b/main.tf
@@ -11,3 +11,155 @@ terraform {
 provider "aws" {
   region = "eu-central-1"
 }
+
+resource "aws_security_group" "alb" {
+  description = "security group from internet to alb"
+  vpc_id      = var.vpc_id
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags = var.tags
+}
+
+resource "aws_route53_record" "app" {
+  zone_id = var.zone_id
+  name    = var.app_url
+  type    = "A"
+  alias {
+    name                   = aws_lb.app.dns_name
+    zone_id                = aws_lb.app.zone_id
+    evaluate_target_health = true
+  }
+}
+
+data "aws_secretsmanager_secret" "app" {
+  count = var.okta_enabled ? 1 : 0
+  name  = var.secret_name
+}
+data "aws_secretsmanager_secret_version" "app" {
+  count     = var.okta_enabled ? 1 : 0
+  secret_id = data.aws_secretsmanager_secret.app[count.index].id
+}
+
+resource "aws_acm_certificate" "app" {
+  domain_name       = var.app_url
+  validation_method = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags = var.tags
+}
+
+resource "aws_route53_record" "app_ssl_validation" {
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.app.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.app.domain_validation_options)[0].resource_record_value]
+  type            = tolist(aws_acm_certificate.app.domain_validation_options)[0].resource_record_type
+  zone_id         = var.zone_id
+  ttl             = 60
+}
+
+resource "aws_acm_certificate_validation" "app" {
+  certificate_arn         = aws_acm_certificate.app.arn
+  validation_record_fqdns = [aws_route53_record.app_ssl_validation.fqdn]
+}
+
+resource "aws_lb" "app" {
+  depends_on         = [aws_security_group.alb]
+  name               = var.name
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = var.subnets
+  security_groups    = [aws_security_group.alb.id]
+  tags               = var.tags
+  access_logs {
+    bucket  = var.log_bucket
+    prefix  = "alb-${var.name}"
+    enabled = var.log_bucket == "" ? false : true
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = "80"
+  protocol          = "HTTP"
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  certificate_arn   = aws_acm_certificate.app.arn
+
+  dynamic "default_action" {
+    for_each = var.okta_enabled ? [1] : []
+    content {
+      type = "authenticate-oidc"
+      authenticate_oidc {
+        authorization_endpoint     = "https://login.tx.group/oauth2/v1/authorize"
+        client_id                  = jsondecode(data.aws_secretsmanager_secret_version.app[0].secret_string)["okta_client_id"]
+        client_secret              = jsondecode(data.aws_secretsmanager_secret_version.app[0].secret_string)["okta_client_secret"]
+        issuer                     = "https://login.tx.group"
+        token_endpoint             = "https://login.tx.group/oauth2/v1/token"
+        user_info_endpoint         = "https://login.tx.group/oauth2/v1/userinfo"
+        session_cookie_name        = "AWSELBAuthSessionCookie"
+        session_timeout            = "3600"
+        scope                      = "openid"
+        on_unauthenticated_request = "authenticate"
+      }
+    }
+  }
+
+  dynamic "default_action" {
+    for_each = var.target_groups
+    content {
+      type             = "forward"
+      target_group_arn = aws_lb_target_group.app[*].arn
+    }
+  }
+}
+
+resource "aws_lb_target_group" "app" {
+  for_each = { for idx, tg in var.target_groups : idx => tg }
+
+  name                 = each.value.name_prefix
+  port                 = each.value.port
+  protocol             = each.value.protocol
+  target_type          = "ip"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 30
+
+  health_check {
+    path     = each.value.health_check.path
+    port     = each.value.health_check.port
+    protocol = each.value.health_check.protocol
+    matcher  = each.value.health_check.matcher
+  }
+  tags = each.value.tags
+}

--- a/main.tf
+++ b/main.tf
@@ -157,7 +157,7 @@ resource "aws_lb_listener_rule" "https_listener_rule" {
     for_each = aws_lb_target_group.app
     content {
       type             = "forward"
-      target_group_arn = aws_lb_target_group[countindex].arn
+      target_group_arn = aws_lb_target_group[count.index].arn
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -47,8 +47,7 @@ data "aws_secretsmanager_secret_version" "app" {
 }
 
 resource "aws_lb_target_group" "app" {
-  for_each = { for idx, tg in var.target_groups : idx => tg }
-
+  for_each             = var.target_groups
   name                 = each.value.name
   port                 = each.value.port
   protocol             = each.value.protocol
@@ -128,25 +127,25 @@ resource "aws_lb_listener" "https" {
   }
 }
 
-resource "aws_lb_listener_rule" "https_listener_rule" {
-  for_each = aws_lb_target_group.app
-  listener_arn = aws_lb_listener.https.arn
-
-  dynamic "condition" {
-    content {
-      path_pattern {
-        values = ["/${each.value.name}/*"]
-      }
-    }
-  }
-
-  dynamic "action" {
-    content {
-      type             = "forward"
-      target_group_arn = each.value.arn
-    }
-  }
-}
+#resource "aws_lb_listener_rule" "https_listener_rule" {
+#  for_each = aws_lb_target_group.app
+#  listener_arn = aws_lb_listener.https.arn
+#
+#  dynamic "condition" {
+#    content {
+#      path_pattern {
+#        values = ["/${each.value.name}/*"]
+#      }
+#    }
+#  }
+#
+#  dynamic "action" {
+#    content {
+#      type             = "forward"
+#      target_group_arn = each.value.arn
+#    }
+#  }
+#}
 
 resource "aws_acm_certificate" "app" {
   domain_name       = var.app_url

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,25 @@
+output "load_balancer_dns_name" {
+  description = "The DNS of the load balancer."
+  value       = aws_lb.app.dns_name
+}
+
+output "load_balancer_arn_suffix" {
+  description = "The ARN suffix of the load balancer."
+  value       = aws_lb.app.arn_suffix
+}
+
+output "load_balancer_arn" {
+  description = "The ARN sffix of the load balancer."
+  value       = aws_lb.app.arn
+}
+
+
+output "target_group_arns" {
+  description = "A list of ARNs for all target groups associated with the load balancer."
+  value       = aws_lb_target_group.app[*].arn
+}
+
+output "target_group_arns_suffix" {
+  description = "A list of ARNs suffix for all target groups associated with the load balancer."
+  value       = aws_lb_target_group.app[*].arn_suffix
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,23 +3,23 @@ output "load_balancer_dns_name" {
   value       = aws_lb.app.dns_name
 }
 
-output "load_balancer_arn_suffix" {
-  description = "The ARN suffix of the load balancer."
-  value       = aws_lb.app.arn_suffix
-}
-
-output "load_balancer_arn" {
-  description = "The ARN sffix of the load balancer."
-  value       = aws_lb.app.arn
-}
-
-
-output "target_group_arns" {
-  description = "A list of ARNs for all target groups associated with the load balancer."
-  value       = aws_lb_target_group.app[*].arn
-}
-
-output "target_group_arns_suffix" {
-  description = "A list of ARNs suffix for all target groups associated with the load balancer."
-  value       = aws_lb_target_group.app[*].arn_suffix
-}
+#output "load_balancer_arn_suffix" {
+#  description = "The ARN suffix of the load balancer."
+#  value       = aws_lb.app.arn_suffix
+#}
+#
+#output "load_balancer_arn" {
+#  description = "The ARN sffix of the load balancer."
+#  value       = aws_lb.app.arn
+#}
+#
+#
+#output "target_group_arns" {
+#  description = "A list of ARNs for all target groups associated with the load balancer."
+#  value       = aws_lb_target_group.app[*].arn
+#}
+#
+#output "target_group_arns_suffix" {
+#  description = "A list of ARNs suffix for all target groups associated with the load balancer."
+#  value       = aws_lb_target_group.app[*].arn_suffix
+#}

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,7 +13,11 @@ output "load_balancer_arn" {
   value       = aws_lb.app.arn
 }
 
-
+output "virtual_network_name_map_one_input" {
+  description = "Virutal Network Name"
+  value = {for tg in aws_lb_target_group.path: tg.name => tg.arn}
+}
+  
 #output "target_group_arns" {
 #  description = "A list of ARNs for all target groups associated with the load balancer."
 #  value       = aws_lb_target_group.app[*].arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,8 @@ output "default_target_group_arn" {
   description = "Default TG arn"
   value       = aws_lb_target_group.default.arn
 }
+
+output "security_group_id" {
+  description = "The security group ID linked to the load balancer"
+  value       = aws_security_group.alb.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,12 +15,10 @@ output "load_balancer_arn" {
 
 output "path_target_groups_arn" {
   description = "Path base routed TG arn"
-  value = {for tg in aws_lb_target_group.path: tg.name => tg.arn}
+  value       = { for tg in aws_lb_target_group.path : tg.name => tg.arn }
 }
 
 output "default_target_group_arn" {
   description = "Default TG arn"
-  value = aws_lb_target_group.default.arn
+  value       = aws_lb_target_group.default.arn
 }
-  
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,10 +18,10 @@ output "virtual_network_name_map_one_input" {
   value = {for tg in aws_lb_target_group.path: tg.name => tg.arn}
 }
   
-#output "target_group_arns" {
-#  description = "A list of ARNs for all target groups associated with the load balancer."
-#  value       = aws_lb_target_group.app[*].arn
-#}
+output "target_group_arns" {
+  description = "A list of ARNs for all target groups associated with the load balancer."
+  value       = aws_lb_target_group.path[*].arn
+}
 #
 #output "target_group_arns_suffix" {
 #  description = "A list of ARNs suffix for all target groups associated with the load balancer."

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,12 @@ output "load_balancer_dns_name" {
   value       = aws_lb.app.dns_name
 }
 
-#output "load_balancer_arn_suffix" {
-#  description = "The ARN suffix of the load balancer."
-#  value       = aws_lb.app.arn_suffix
-#}
-#
+output "load_balancer_arn_suffix" {
+  description = "The ARN suffix of the load balancer."
+  value       = aws_lb.app.arn_suffix
+}
+
+
 #output "load_balancer_arn" {
 #  description = "The ARN sffix of the load balancer."
 #  value       = aws_lb.app.arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,13 +8,12 @@ output "load_balancer_arn_suffix" {
   value       = aws_lb.app.arn_suffix
 }
 
+output "load_balancer_arn" {
+  description = "The ARN of the load balancer."
+  value       = aws_lb.app.arn
+}
 
-#output "load_balancer_arn" {
-#  description = "The ARN sffix of the load balancer."
-#  value       = aws_lb.app.arn
-#}
-#
-#
+
 #output "target_group_arns" {
 #  description = "A list of ARNs for all target groups associated with the load balancer."
 #  value       = aws_lb_target_group.app[*].arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,17 +13,14 @@ output "load_balancer_arn" {
   value       = aws_lb.app.arn
 }
 
-output "virtual_network_name_map_one_input" {
-  description = "Virutal Network Name"
+output "path_target_groups_arn" {
+  description = "Path base routed TG arn"
   value = {for tg in aws_lb_target_group.path: tg.name => tg.arn}
 }
-  
-output "target_group_arns" {
-  description = "A list of ARNs for all target groups associated with the load balancer."
-  value       = aws_lb_target_group.path[*].arn
+
+output "default_target_group_arn" {
+  description = "Default TG arn"
+  value = aws_lb_target_group.default.arn
 }
-#
-#output "target_group_arns_suffix" {
-#  description = "A list of ARNs suffix for all target groups associated with the load balancer."
-#  value       = aws_lb_target_group.app[*].arn_suffix
-#}
+  
+

--- a/variables.tf
+++ b/variables.tf
@@ -65,9 +65,9 @@ variable "log_bucket" {
 /*
   target_groups = [
     {
-      name_prefix = "web-app-tg"
+      name = "ws"
       protocol = "HTTP"
-      port = 80
+      port = 3000
       health_check = {
         path = "/health"
         port = "traffic-port"
@@ -80,7 +80,7 @@ variable "log_bucket" {
       }
     },
     {
-      name_prefix = "api-tg"
+      name = "api"
       protocol = "HTTP"
       port = 8080
       health_check = {

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "secret_name" {
 }
 
 variable "log_bucket" {
-  description = "the S3 Bucket where to store the logs - if the bucekt name is empty logging is disabled "
+  description = "the existing S3 Bucket name where to store the logs - if the bucket name is empty logging is disabled "
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
   type        = string
 }
 
-variable "target_groups" {
+variable "path_target_groups" {
   description = "Definition of the target groups. Each target group is accessed via path based routing."
   type = list(object({
     name     = string
@@ -17,6 +17,23 @@ variable "target_groups" {
     })
     tags = map(string)
   }))
+}
+
+
+variable "default_target_group" {
+  description = "Definition of the default target group. The one reachable by default ('/')."
+  type = object({
+    name     = string
+    protocol = string
+    port     = number
+    health_check = object({
+      path     = string
+      port     = string
+      protocol = string
+      matcher  = string
+    })
+    tags = map(string)
+  })
 }
 
 variable "subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,98 @@
+variable "name" {
+  description = "The name for the load balancer."
+  type        = string
+}
+
+variable "target_groups" {
+  description = "Definition of the target groups. Each target group is accessed via path based routing."
+  type = list(object({
+    name     = string
+    protocol = string
+    port     = number
+    health_check = object({
+      path     = string
+      port     = string
+      protocol = string
+      matcher  = string
+    })
+    tags = map(string)
+  }))
+}
+
+variable "subnets" {
+  description = "A list of public subnet IDs for the load balancer."
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "A map of tags to apply to the load balancer and associated resources."
+  type        = map(string)
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC in which to create the load balancer."
+  type        = string
+}
+
+variable "app_url" {
+  description = "the domain name of the Application"
+  type        = string
+}
+
+variable "zone_id" {
+  description = "the Route 53 zone id"
+  type        = string
+}
+
+variable "okta_enabled" {
+  description = "if okta is enabled or not for the ALB"
+  type        = bool
+  default     = false
+}
+
+variable "secret_name" {
+  description = "the AWS Secret manager Secret name of the Secret where okta id and okta secret are stored. They should be stored as okta_client_id and okta_client_secret key"
+  type        = string
+  default     = ""
+}
+
+variable "log_bucket" {
+  description = "the S3 Bucket where to store the logs - if the bucekt name is empty logging is disabled "
+  type        = string
+  default     = ""
+}
+
+/*
+  target_groups = [
+    {
+      name_prefix = "web-app-tg"
+      protocol = "HTTP"
+      port = 80
+      health_check = {
+        path = "/health"
+        port = "traffic-port"
+        protocol = "HTTP"
+        matcher = "200"
+      }
+      tags = {
+        Name = "Orchestrator"
+        Environment = "Production"
+      }
+    },
+    {
+      name_prefix = "api-tg"
+      protocol = "HTTP"
+      port = 8080
+      health_check = {
+        path = "/health"
+        port = "traffic-port"
+        protocol = "HTTP"
+        matcher = "200"
+      }
+      tags = {
+        Name = "Admin"
+        Environment = "Production"
+      }
+    }
+  ]
+  */


### PR DESCRIPTION
[FUM-2423](https://jira.tx.group/browse/FUM-2423)
supporting multiple TG in alb-ecs module

It's in charge of creating/managing:
- ALB
- Listeners (http/https), redirection
- Target groups (default ("/") + path based routing)
- ALB Logging (optional)
- Okta authentication (optional)
- Route53 records/SSL Validation

Some more verbose description were added into the readme file.

Sample usage of the module -> https://github.com/tx-pts-dai/ness-nebula-infra/pull/14 