### PR TITLE
fix: make DNS records creation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Module for handling application load balancers, listeners, target groups and rou
 Security groups are handled internally and only allow http and https traffic in.
 
 ## Usage
+
 ```hcl
 module "lb" {
   source               = "github.com/tx-pts-dai/terraform-aws-lb"
@@ -31,6 +32,7 @@ module "lb" {
 ```
 
 As optional, extra target groups can be set. Those could be then reached through path based routing. Each target group must specify the following properties. As optional, they can have dedicated tags and health checks properties.
+
 ```hcl
 module "lb" {
   source               = "github.com/tx-pts-dai/terraform-aws-lb"
@@ -71,23 +73,42 @@ module "lb" {
 For other optional inputs, see Inputs section
 
 ## Enabling logging
+
 ALB logs can be enabled by setting the following input:
+
 ```hcl
   "log_bucket" = "arn-of-an-existing-bucket"
 ```
+
 When empty, there are no logs saved.
 
 ## Enabling OKTA
+
 OKTA can be enabled with the following inputs:
+
 ```hcl
   okta_enabled = true
   secret_name  = "aws-secret-name"
 ```
 
 The secret is a JSON key-value pair that must contain the following keys:
+
 - okta_client_id
 - okta_client_secret
 - okta_login_url
+
+## DNS
+
+The A and CNAME DNS records for the loadbalancer and the AWS certificate validation will automatically be created by giving the AWS Route53 ZoneID were too create them:
+
+```hcl
+  zone_id = "AWS_ROUTER53_ZONEID"
+```
+
+Otherwise, the following records need to be set in the DNS zone:
+
+- CNAME to the loadbalancer (to have a "nice" name for the service)
+- CNAME for the AWS Certificate validation
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ The secret is a JSON key-value pair that must contain the following keys:
 
 ## DNS
 
-The A and CNAME DNS records for the loadbalancer and the AWS certificate validation will automatically be created by giving the AWS Route53 ZoneID were too create them:
+The A and CNAME DNS records for the loadbalancer and the AWS certificate validation will automatically be created by giving the AWS Route53 ZoneID were to create them:
 
 ```hcl
   zone_id = "AWS_ROUTER53_ZONEID"
 ```
 
-Otherwise, the following records need to be set in the DNS zone:
+If the worlflow doesn't have permissions to the AWS Route53 Zone OR if the zone is not managed by Route53 (Cloudflare for example), then the *zone_id* parameter should be "" and the following records need to be created manually:
 
 - CNAME to the loadbalancer (to have a "nice" name for the service)
 - CNAME for the AWS Certificate validation
@@ -181,7 +181,7 @@ No modules.
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of public subnet IDs for the load balancer. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to the load balancer and associated resources. | `map(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC in which to create the load balancer. | `string` | n/a | yes |
-| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | the Route 53 zone id | `string` | n/a | yes |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | If set, the Route 53 zone id into which the DNS records will be created | `string` | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,8 @@ resource "aws_security_group" "alb" {
 }
 
 resource "aws_route53_record" "app" {
+  count = var.zone_id != "" ? 1 : 0
+
   zone_id = var.zone_id
   name    = var.app_url
   type    = "A"
@@ -175,6 +177,8 @@ resource "aws_acm_certificate" "app" {
 }
 
 resource "aws_route53_record" "app_ssl_validation" {
+  count = var.zone_id != "" ? 1 : 0
+
   allow_overwrite = true
   name            = tolist(aws_acm_certificate.app.domain_validation_options)[0].resource_record_name
   records         = [tolist(aws_acm_certificate.app.domain_validation_options)[0].resource_record_value]
@@ -184,6 +188,8 @@ resource "aws_route53_record" "app_ssl_validation" {
 }
 
 resource "aws_acm_certificate_validation" "app" {
+  count = var.zone_id != "" ? 1 : 0
+
   certificate_arn         = aws_acm_certificate.app.arn
-  validation_record_fqdns = [aws_route53_record.app_ssl_validation.fqdn]
+  validation_record_fqdns = [aws_route53_record.app_ssl_validation[0].fqdn]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -60,8 +60,9 @@ variable "app_url" {
 }
 
 variable "zone_id" {
-  description = "the Route 53 zone id"
+  description = "If set, the Route 53 zone id into which the DNS records will be created"
   type        = string
+  default     = ""
 }
 
 variable "okta_enabled" {


### PR DESCRIPTION
Make the DNS records creation an option.
Needed is case the LB is not in a DNS domain managed by a AWS Route53 zone (for zone "tamedia.ch" which is managed in cloudflare) or if we don't have access to the AWS Route53 zone.