### PR TITLE
fix: create acm_validation in any case

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -188,8 +188,6 @@ resource "aws_route53_record" "app_ssl_validation" {
 }
 
 resource "aws_acm_certificate_validation" "app" {
-  count = var.zone_id != "" ? 1 : 0
-
   certificate_arn         = aws_acm_certificate.app.arn
   validation_record_fqdns = [aws_route53_record.app_ssl_validation[0].fqdn]
 }


### PR DESCRIPTION
acm_validation should be created even if the route53 record should not