### PR TITLE
feat: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terraform-aws-lb
+  namespace: tx-pts-dai
+  description: terraform-aws-lb component
+  annotations:
+    github.com/project-slug: tx-pts-dai/terraform-aws-lb
+  tags:
+    - tx-pts-dai
+spec:
+  type: infrastructure
+  lifecycle: production
+  owner: group:default/dai


### PR DESCRIPTION
## Summary

Adds a `catalog-info.yaml` so this repo is automatically discovered by Backstage.

Once merged, this repo will appear in the [Backstage catalog](https://backstage.dai.tamedia.tech/catalog) with its deployment status, CI/CD, docs, and more.

The `backstage` GitHub topic has been added to this repo to enable auto-discovery.

## What changed

- Added `catalog-info.yaml` at repo root
- Added `backstage` GitHub topic

No code changes. No runtime impact.